### PR TITLE
Use  type variable also in Font-Family name.

### DIFF
--- a/roboto-fontface.scss
+++ b/roboto-fontface.scss
@@ -2,7 +2,7 @@ $roboto-font-path: 'fonts' !default;
 
 @mixin roboto-font($type, $weight, $style: normal) {
     @font-face {
-        font-family: 'Roboto';
+        font-family: 'Roboto-#{$type}';
         src: url('#{$roboto-font-path}/Roboto-#{$type}.eot');
         src: url('#{$roboto-font-path}/Roboto-#{$type}.eot?#iefix') format('embedded-opentype'),
              url('#{$roboto-font-path}/Roboto-#{$type}.woff2') format('woff2'),


### PR DESCRIPTION
Currently all variants of the font get the same name "Roboto" that makes no sense.
