### PR TITLE
Correct src in second @font-face block

### DIFF
--- a/css/mixins.scss
+++ b/css/mixins.scss
@@ -20,7 +20,7 @@ $roboto-font-path: '../../../fonts' !default;
 
     @font-face {
         font-family: '#{$variant}-#{$type}';
-        src: url('#{$font-full-path}/#{$variant}-#{$type}.eot');
+        src: url('#{$font-full-path}-#{$type}.eot');
         src: local('#{$variant} #{$type}'),
              local('#{$variant}-#{$type}'),
              url('#{$font-full-path}-#{$type}.eot?#iefix') format('embedded-opentype'),


### PR DESCRIPTION
Extra forward slash and #{$variant} add an extra level of directory structure which doesn't match the actual directory structure or the other src urls.