### PR TITLE
Update roboto-font-path to be relative to the package name

### DIFF
--- a/css/mixins.scss
+++ b/css/mixins.scss
@@ -1,4 +1,4 @@
-$roboto-font-path: '../../../fonts' !default;
+$roboto-font-path: '~roboto-fontface/fonts' !default;
 
 @mixin roboto-font($variant, $type, $weight, $style) {
 


### PR DESCRIPTION
This allows the mixin to avoid using relative URLs. This is troublesome when using tools like webpack.