### PR TITLE
Fixes wrong path for Roboto in the filesystem

### DIFF
--- a/css/mixins.scss
+++ b/css/mixins.scss
@@ -2,7 +2,7 @@ $roboto-font-path: '../../../fonts' !default;
 
 @mixin roboto-font($variant, $type, $weight, $style) {
 
-    $font-full-path: '#{$roboto-font-path}/#{$variant}/#{$variant}';
+    $font-full-path: '#{$roboto-font-path}/#{to-lower-case($variant)}/#{$variant}';
 
     @font-face {
         font-family: '#{$variant}';


### PR DESCRIPTION
Fonts are available under fonts/roboto/Roboto-*, whereas
SCSS references to them always as Roboto. Filesystem is
case-sensitive, therefore this patch makes SCSS use the
correct path to the file by lowercasing the variable used.

This is to resolve #41 