### PR TITLE
Use latin unicode to fix IE rendering issue

### DIFF
--- a/css/mixins.less
+++ b/css/mixins.less
@@ -16,6 +16,7 @@
              url('@{font-full-path}-@{type}.svg#@{variant}') format('svg');
         font-weight: @weight;
         font-style: @style;
+        unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
     }
 
     @font-face {
@@ -28,5 +29,6 @@
              url('@{font-full-path}-@{type}.woff') format('woff'),
              url('@{font-full-path}-@{type}.ttf') format('truetype'),
              url('@{font-full-path}-@{type}.svg#@{variant}') format('svg');
+       unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
     }
 }

--- a/css/mixins.scss
+++ b/css/mixins.scss
@@ -16,6 +16,7 @@ $roboto-font-path: '../../../fonts' !default;
              url('#{$font-full-path}-#{$type}.svg##{$variant}') format('svg');
         font-weight: $weight;
         font-style: $style;
+        unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
     }
 
     @font-face {
@@ -28,5 +29,6 @@ $roboto-font-path: '../../../fonts' !default;
              url('#{$font-full-path}-#{$type}.woff') format('woff'),
              url('#{$font-full-path}-#{$type}.ttf') format('truetype'),
              url('#{$font-full-path}-#{$type}.svg##{$variant}') format('svg');
+       unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
     }
 }

--- a/css/roboto-condensed/roboto-condensed-fontface.css
+++ b/css/roboto-condensed/roboto-condensed-fontface.css
@@ -32,6 +32,7 @@
     src: local("Roboto-Condensed Light"), local("Roboto-Condensed-Light"), url("../../fonts/roboto-condensed/Roboto-Condensed-Light.eot?#iefix") format("embedded-opentype"), url("../../fonts/roboto-condensed/Roboto-Condensed-Light.woff2") format("woff2"), url("../../fonts/roboto-condensed/Roboto-Condensed-Light.woff") format("woff"), url("../../fonts/roboto-condensed/Roboto-Condensed-Light.ttf") format("truetype"), url("../../fonts/roboto-condensed/Roboto-Condensed-Light.svg#Roboto-Condensed") format("svg");
     font-weight: 300;
     font-style: normal;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -46,6 +47,7 @@
     src: local("Roboto-Condensed LightItalic"), local("Roboto-Condensed-LightItalic"), url("../../fonts/roboto-condensed/Roboto-Condensed-LightItalic.eot?#iefix") format("embedded-opentype"), url("../../fonts/roboto-condensed/Roboto-Condensed-LightItalic.woff2") format("woff2"), url("../../fonts/roboto-condensed/Roboto-Condensed-LightItalic.woff") format("woff"), url("../../fonts/roboto-condensed/Roboto-Condensed-LightItalic.ttf") format("truetype"), url("../../fonts/roboto-condensed/Roboto-Condensed-LightItalic.svg#Roboto-Condensed") format("svg");
     font-weight: 300;
     font-style: italic;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {

--- a/css/roboto-slab/roboto-slab-fontface.css
+++ b/css/roboto-slab/roboto-slab-fontface.css
@@ -4,6 +4,7 @@
     src: local('Roboto-Slab Thin'), local('Roboto-Slab-Thin'), url('../../fonts/roboto-slab/Roboto-Slab-Thin.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto-slab/Roboto-Slab-Thin.woff2') format('woff2'), url('../../fonts/roboto-slab/Roboto-Slab-Thin.woff') format('woff'), url('../../fonts/roboto-slab/Roboto-Slab-Thin.ttf') format('truetype'), url('../../fonts/roboto-slab/Roboto-Slab-Thin.svg#Roboto-Slab') format('svg');
     font-weight: 100;
     font-style: normal;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -18,6 +19,7 @@
     src: local('Roboto-Slab Light'), local('Roboto-Slab-Light'), url('../../fonts/roboto-slab/Roboto-Slab-Light.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto-slab/Roboto-Slab-Light.woff2') format('woff2'), url('../../fonts/roboto-slab/Roboto-Slab-Light.woff') format('woff'), url('../../fonts/roboto-slab/Roboto-Slab-Light.ttf') format('truetype'), url('../../fonts/roboto-slab/Roboto-Slab-Light.svg#Roboto-Slab') format('svg');
     font-weight: 300;
     font-style: normal;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {

--- a/css/roboto/roboto-fontface.css
+++ b/css/roboto/roboto-fontface.css
@@ -4,6 +4,7 @@
     src: local('Roboto Thin'), local('Roboto-Thin'), url('../../fonts/roboto/Roboto-Thin.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto/Roboto-Thin.woff2') format('woff2'), url('../../fonts/roboto/Roboto-Thin.woff') format('woff'), url('../../fonts/roboto/Roboto-Thin.ttf') format('truetype'), url('../../fonts/roboto/Roboto-Thin.svg#Roboto') format('svg');
     font-weight: 100;
     font-style: normal;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -18,6 +19,7 @@
     src: local('Roboto ThinItalic'), local('Roboto-ThinItalic'), url('../../fonts/roboto/Roboto-ThinItalic.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto/Roboto-ThinItalic.woff2') format('woff2'), url('../../fonts/roboto/Roboto-ThinItalic.woff') format('woff'), url('../../fonts/roboto/Roboto-ThinItalic.ttf') format('truetype'), url('../../fonts/roboto/Roboto-ThinItalic.svg#Roboto') format('svg');
     font-weight: 100;
     font-style: italic;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -32,6 +34,7 @@
     src: local('Roboto Light'), local('Roboto-Light'), url('../../fonts/roboto/Roboto-Light.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto/Roboto-Light.woff2') format('woff2'), url('../../fonts/roboto/Roboto-Light.woff') format('woff'), url('../../fonts/roboto/Roboto-Light.ttf') format('truetype'), url('../../fonts/roboto/Roboto-Light.svg#Roboto') format('svg');
     font-weight: 300;
     font-style: normal;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -46,6 +49,7 @@
     src: local('Roboto LightItalic'), local('Roboto-LightItalic'), url('../../fonts/roboto/Roboto-LightItalic.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto/Roboto-LightItalic.woff2') format('woff2'), url('../../fonts/roboto/Roboto-LightItalic.woff') format('woff'), url('../../fonts/roboto/Roboto-LightItalic.ttf') format('truetype'), url('../../fonts/roboto/Roboto-LightItalic.svg#Roboto') format('svg');
     font-weight: 300;
     font-style: italic;
+    unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {

--- a/test.html
+++ b/test.html
@@ -3,6 +3,7 @@
 
 <head>
     <title>Test Font Face</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
     <link rel="stylesheet" href="css/roboto/roboto-fontface.css">
     <link rel="stylesheet" href="css/roboto-condensed/roboto-condensed-fontface.css">
     <link rel="stylesheet" href="css/roboto-slab/roboto-slab-fontface.css">
@@ -32,6 +33,16 @@
 
         .roboto {
             font-family: 'Roboto';
+        }
+
+        .roboto-fw-100 {
+            font-family: 'Roboto', sans-serif;
+            font-weight: 100;
+        }
+
+        .roboto-fw-300 {
+            font-family: 'Roboto', sans-serif;
+            font-weight: 300;
         }
 
         .roboto-italic {
@@ -126,6 +137,20 @@
         </header>
         CSS on its own can be fun, but stylesheets are getting larger, more complex, and harder to maintain. This is where a preprocessor can help. Sass lets you use features that don't exist in CSS yet like variables, nesting, mixins, inheritance and other nifty
         goodies that make writing CSS fun again.
+    </section>
+
+    <section class="roboto-fw-100">
+        <header>
+            <h1>I am Roboto with font-weight 100</h1>
+        </header>
+         Áge age, i puere, dúc me ad patrios fínes decoratum ópipare! Nosinės raidės – tai lietuvių kalbos ortografijos [gr. orthos – tiesus, taisyklingas; gr. grapho – rašau; ortografija – visų pripažinta kurios nors kalbos rašymo sistema] tradicija, sauganti lietuvių kalbos senovės paveldą.
+    </section>
+
+    <section class="roboto-fw-300">
+        <header>
+            <h1>I am Roboto with font-weight 300</h1>
+        </header>
+         Áge age, i puere, dúc me ad patrios fínes decoratum ópipare! Nosinės raidės – tai lietuvių kalbos ortografijos [gr. orthos – tiesus, taisyklingas; gr. grapho – rašau; ortografija – visų pripažinta kurios nors kalbos rašymo sistema] tradicija, sauganti lietuvių kalbos senovės paveldą.
     </section>
 
     <section class="roboto-italic">


### PR DESCRIPTION
@choffmeister,
issue: 
<img width="350" alt="screen shot 2017-10-09 at 2 34 54 pm" src="https://user-images.githubusercontent.com/9293338/31336333-0fc167d2-acff-11e7-908b-29c4a6464baf.png">

How to represent this bug:
```css
font-family: 'Roboto', sans-serif;
font-weight: 300;
```